### PR TITLE
refined both the fun and nickrequest cog

### DIFF
--- a/bot/cogs/fun/fun.py
+++ b/bot/cogs/fun/fun.py
@@ -1,5 +1,6 @@
 import discord
 from discord.ext import commands
+import asyncio
 
 from bot.bot import Bot
 
@@ -20,10 +21,9 @@ class fun(commands.Cog):
         if isinstance(error, commands.CommandOnCooldown):
             # this sends an error if the command is used too often
             msg = 'This command is ratelimited, please try again in {:.2f}s'.format(error.retry_after)
-            message = await ctx.channel.send(msg)
+            await ctx.send(msg, delete_after=5)
             await asyncio.sleep(5)
             await ctx.message.delete()
-            await message.delete()
         else:
             raise error
 

--- a/bot/cogs/utility/nickrequest.py
+++ b/bot/cogs/utility/nickrequest.py
@@ -83,7 +83,7 @@ class Nickrequest(commands.Cog):
             await asyncio.sleep(3)
             await msg.delete()
         elif emoji == '❌':
-            await user.send("Your nickname change request was denied.")
+            await user.send(f"Your nickname change to {nickname}, was denied.")
             await asyncio.sleep(3)
             await msg.delete()
 

--- a/bot/cogs/utility/nickrequest.py
+++ b/bot/cogs/utility/nickrequest.py
@@ -19,76 +19,88 @@ class Nickrequest(commands.Cog):
     @commands.command(name="nick")
     @commands.cooldown(1, command_timeout, commands.BucketType.user)
     async def nick(self, ctx: commands.Context, *, nick: str):
-        rq_channel = self.bot.get_channel(accept_channel_id)
+        acc_channel = self.bot.get_channel(accept_channel_id)
 
         # this looks if the request is valid
         if not nick:
-            await ctx.send(f'{ctx.author.mention}, please mention a nick to change to.',delete_after=5)
+            await ctx.send(f'{ctx.author.mention}, please mention a nick to change to.', delete_after=5)
             await ctx.message.delete()
             return
         if ctx.channel.id != request_channel_id:
-            await ctx.send(f'{ctx.author.mention}, please use the correct channel.',delete_after=5)
+            await ctx.send(f'{ctx.author.mention}, please use the correct channel.', delete_after=5)
             await ctx.message.delete()
             return
 
         if len(nick) > 32:
-            message = await ctx.send(f'{ctx.author.mention}, please mention a nick with 32 characters or less.',delete_after=5)
+            await ctx.send(f'{ctx.author.mention}, please mention a nick with 32 characters or less.', delete_after=5)
             await ctx.message.delete()
             return
 
         # this sends the embed to the selected channel
-        embed = discord.Embed(title="Nickname Change Request",color=0x00ff00)
-        embed.set_field(name="Current Nick",value=f"{ctx.author.nick}")
-        embed.set_field(name="Requested Nick",value=f"{nick}")
+        embed = discord.Embed(title="Nickname Change Request", color=8359053)
+        embed.add_field(name="Current Nick", value=f"{ctx.author.nick}")
+        embed.add_field(name="Requested Nick", value=f"{nick}")
         embed.set_author(name=f"{ctx.author.name}#{ctx.author.discriminator}", icon_url=ctx.author.avatar_url)
-        embed.set_field(name="Requester",value="{ctx.author.mention}")
-        embed.set_footer(text=f"{ctx.author.id}")
+        embed.add_field(name="Requester", value=f"{ctx.author.mention}")
         await ctx.message.add_reaction("✅")
-        message = await rq_channel.send(embed=embed)
+        message = await acc_channel.send(embed=embed)
         await message.add_reaction("✅")
         await message.add_reaction("❌")
-        await asyncio.sleep(10)
+        await asyncio.sleep(5)
         await ctx.message.delete()
 
     @commands.Cog.listener(name="on_raw_reaction_add")
     async def on_raw_reaction_add(self, payload):
         # this rules out other reactions
-        if payload.channel_id != accept_channel_id:
+        if payload.channel_id != accept_channel_id or payload.user_id == self.bot.user.id:
             return
-        if payload.user_id == self.bot.user.id:
+        emoji = payload.emoji.name
+        if emoji not in ['✅', '❌']:
             return
 
         # this get the channel, user, emoji and message
         channel = self.bot.get_channel(id=payload.channel_id)
         msg = await channel.fetch_message(payload.message_id)
-        emoji = payload.emoji.name
 
         server = self.bot.get_guild(msg.guild.id)
-        
+
         easy_embed = msg.embeds[0].to_dict()
-        user = server.get_member(int(easy_embed['fields'][2]['value'][2:-1]))
+        user = server.get_member(int(easy_embed['fields'][2]['value'][3:-1]))
+        reactor = server.get_member(int(payload.user_id))
         nickname = easy_embed['fields'][1]['value']
-        
+
+        if emoji == '✅':
+            embed = discord.Embed(title="Nickname Change Request", color=3066993)
+        elif emoji == '❌':
+            embed = discord.Embed(title="Nickname Change Request", color=15158332)
+        else:
+            return
+
+        embed.add_field(name="Current Nick", value=f"{user.nick}")
+        embed.add_field(name="Requested Nick", value=f"{nickname}")
+        embed.set_author(name=f"{user.name}#{user.discriminator}", icon_url=user.avatar_url)
+        embed.add_field(name="Requester", value=f"{user.mention}")
 
         # this applies the nickname or notifies the user of the denied request
         if emoji == '✅':
+            embed.add_field(name="Accepted by", value=f"{reactor.mention}")
+            await msg.edit(embed=embed)
+            await msg.clear_reactions()
             await user.edit(nick=nickname)
-            await asyncio.sleep(3)
-            await msg.delete()
         elif emoji == '❌':
+            embed.add_field(name="Denied by", value=f"{reactor.mention}")
+            await msg.edit(embed=embed)
+            await msg.clear_reactions()
             await user.send(f"Your nickname change to {nickname}, was denied.")
-            await asyncio.sleep(3)
-            await msg.delete()
 
     @nick.error
     async def nick_error(self, ctx, error):
         if isinstance(error, commands.CommandOnCooldown):
             # this sends an error if the command is used too often
             msg = 'This command is ratelimited, please try again in {:.2f}s'.format(error.retry_after)
-            message = await ctx.channel.send(msg)
+            await ctx.send(msg, delete_after=5)
             await asyncio.sleep(5)
             await ctx.message.delete()
-            await message.delete()
         else:
             raise error
 


### PR DESCRIPTION
The fun cog was refined, while the nickrequest cog got error fixes, a change so that requests now stay in the channel and are color coded: grey = outstanding request, green = accepted request, red = denied request