### PR TITLE
fix: replace references to "Big Brain" with "Private Chat Access"

### DIFF
--- a/bot/cogs/utility/antimassping.py
+++ b/bot/cogs/utility/antimassping.py
@@ -8,7 +8,7 @@ class AntiMassPing(commands.Cog):
 
     @commands.Cog.listener(name="on_message")
     async def mess(self,message_object):
-        if any(role_check in ['Big Brain','Moderator','Administrator'] for role_check in [role.name for role in message_object.author.roles]):
+        if any(role_check in ['Private Chat Access', 'Moderator', 'Administrator', 'Staff'] for role_check in [role.name for role in message_object.author.roles]):
             return
         matches = set(message_object.mentions)
         if len(matches) < self.max_mentions:

--- a/bot/cogs/utility/general.py
+++ b/bot/cogs/utility/general.py
@@ -89,7 +89,7 @@ class General(commands.Cog):
         await self.bot.close()
 
     @commands.command(name="ping")
-    @commands.has_any_role("Administrator", "Moderator", "Big Brain")
+    @commands.has_any_role("Private Chat Access", "Moderator", "Administrator", "Staff")
     async def ping(self, ctx: commands.Context, p: int = 2):
         t_start = time.time()
         m = await ctx.channel.send("Testing RTT for message editing.")

--- a/bot/cogs/utility/links.py
+++ b/bot/cogs/utility/links.py
@@ -28,7 +28,7 @@ class Links(commands.Cog):
                 return await message.delete()
 
     @commands.command()
-    @commands.has_any_role("Administrator", "Moderator", "Big Brain")
+    @commands.has_any_role("Private Chat Access", "Moderator", "Administrator", "Staff")
     async def shorturl(self, ctx, url, short=None):
         """ creates a short mcatho.me url """
         try:
@@ -45,7 +45,7 @@ class Links(commands.Cog):
             await ctx.send("The keyword probably already exists! `"+short+"`", delete_after=10)
 
     @commands.command()
-    @commands.has_any_role("Administrator", "Moderator", "Big Brain")
+    @commands.has_any_role("Private Chat Access", "Moderator", "Administrator", "Staff")
     async def urlstats(self, ctx, url=None):
         """ Get Stats from shortend URL's """
         if url == None:


### PR DESCRIPTION
Right now PCA can't use !ping or shorturls because it expects us to be Big Brain.